### PR TITLE
fix(zoom-update.sh): fix already at latest version detection

### DIFF
--- a/autoupdate-zoom.sh
+++ b/autoupdate-zoom.sh
@@ -32,6 +32,7 @@ case "$subcommand" in
     mkdir /opt/zoom-updater
 cat <<EOF > /opt/zoom-updater/zoom-update.sh
 #!/bin/bash
+export LANG=en
 ZOOM_VERSION_AVAILABLE=\$(curl -s 'https://zoom.us/support/download' --header 'User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.75 Safari/537.36' | grep "class=\"linux-ver-text\"" | sed -e 's/.*Version \(.*\)<.*/\1/')
 echo zoom version available for download: \$ZOOM_VERSION_AVAILABLE
 ZOOM_VERSION_AVAILABLE_MAJOR=\$(echo \$ZOOM_VERSION_AVAILABLE | sed -e 's/\([^\.]\+\.[^\.]\+\).*/\1/')


### PR DESCRIPTION
The already at latest version detection dose not work on non English systems. ```grep "Installed:"``` dose not work because it is named different in other languages. Therefore I set the lang to en. 