### PR TITLE
New http request that returns redirect including version

### DIFF
--- a/autoupdate-zoom.sh
+++ b/autoupdate-zoom.sh
@@ -34,7 +34,10 @@ install)
     cat <<'EOF' >/opt/zoom-updater/zoom-update.sh
 #!/bin/bash
 export LANG=en
-ZOOM_VERSION_AVAILABLE=$(curl -s 'https://zoom.us/support/download' --header 'User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.75 Safari/537.36' | grep "class=\"linux-ver-text\"" | sed -e 's/.*Version \(.*\)<.*/\1/')
+ZOOM_LINK_AND_VERSION=$(wget -S --spider --max-redirect=0 'https://zoom.us/client/latest/zoom_amd64.deb' --header 'User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.75 Safari/537.36' 2>&1 | grep "Location" | sed -E 's/.*(https.*prod\/(.*)\/zoom.*\.deb).*/\1 \2/')
+parts=($ZOOM_LINK_AND_VERSION)
+ZOOM_DOWNLOAD_LINK=${parts[0]}
+ZOOM_VERSION_AVAILABLE=${parts[1]}
 echo zoom version available for download: $ZOOM_VERSION_AVAILABLE
 ZOOM_VERSION_AVAILABLE_MAJOR=$(echo $ZOOM_VERSION_AVAILABLE | sed -e 's/\([^\.]\+\.[^\.]\+\).*/\1/')
 echo "major" zoom version available for download: $ZOOM_VERSION_AVAILABLE_MAJOR
@@ -44,7 +47,7 @@ ZOOM_VERSION_INSTALLED=$(apt-cache policy zoom | grep "Installed:" | sed -e 's/.
 echo zoom version installed: $ZOOM_VERSION_INSTALLED
 if [[ "$ZOOM_VERSION_INSTALLED" != *"$ZOOM_VERSION_AVAILABLE_MINOR"* ]] || [[ "$ZOOM_VERSION_INSTALLED" != *"$ZOOM_VERSION_AVAILABLE_MAJOR"* ]]; then
    echo downloading new version...
-   wget --quiet https://zoom.us/client/latest/zoom_amd64.deb -P /tmp
+   wget --quiet $ZOOM_DOWNLOAD_LINK -P /tmp
    export DEBIAN_FRONTEND=noninteractive
    apt-get install -y /tmp/zoom_amd64.deb
    rm /tmp/zoom_amd64.deb
@@ -57,7 +60,10 @@ EOF
     cat <<'EOF' >/opt/zoom-updater/zoom-update.sh
 #!/bin/bash
 export LANG=en_US
-ZOOM_VERSION_AVAILABLE=$(curl -s 'https://zoom.us/support/download' --header 'User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.75 Safari/537.36' | grep "class=\"linux-ver-text\"" | sed -e 's/.*Version \(.*\)<.*/\1/')
+ZOOM_LINK_AND_VERSION=$(wget -S --spider --max-redirect=0 'https://zoom.us/client/latest/zoom_x86_64.rpm' --header 'User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.75 Safari/537.36' 2>&1 | grep "Location" | sed -E 's/.*(https.*prod\/(.*)\/zoom.*\.rpm).*/\1 \2/')
+parts=($ZOOM_LINK_AND_VERSION)
+ZOOM_DOWNLOAD_LINK=${parts[0]}
+ZOOM_VERSION_AVAILABLE=${parts[1]}
 echo zoom version available for download: $ZOOM_VERSION_AVAILABLE
 ZOOM_VERSION_AVAILABLE_MAJOR=$(echo $ZOOM_VERSION_AVAILABLE | sed -e 's/\([^\.]\+\.[^\.]\+\).*/\1/')
 echo "major" zoom version available for download: $ZOOM_VERSION_AVAILABLE_MAJOR
@@ -67,7 +73,7 @@ ZOOM_VERSION_INSTALLED=$(dnf list installed zoom.x86_64 | grep "zoom.x86_64" | s
 echo zoom version installed: $ZOOM_VERSION_INSTALLED
 if [[ "$ZOOM_VERSION_INSTALLED" != *"$ZOOM_VERSION_AVAILABLE_MINOR"* ]] || [[ "$ZOOM_VERSION_INSTALLED" != *"$ZOOM_VERSION_AVAILABLE_MAJOR"* ]]; then
    echo downloading new version...
-   wget --quiet https://zoom.us/client/latest/zoom_x86_64.rpm -P /tmp
+   wget --quiet $ZOOM_DOWNLOAD_LINK -P /tmp
    dnf install -y /tmp/zoom_x86_64.rpm
    rm /tmp/zoom_x86_64.rpm
 else


### PR DESCRIPTION
Based on the observation by @kputyra in the [This issue](https://github.com/pazepaze/zoom-autoupdater/issues/5)
-The script reads the response without following the redirect 
-Extracts the download URL and the version from the response 
-Uses the extracted version for the comparison
-Uses the extracted URL for downloading